### PR TITLE
add optional fields

### DIFF
--- a/cam_examples/basic_cam.json
+++ b/cam_examples/basic_cam.json
@@ -1,7 +1,7 @@
 {
   "type": "cam",
   "origin": "self",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "source_uuid": "uuid14",
   "timestamp": 1574778515424,
   "message": {

--- a/cam_examples/full_cam.json
+++ b/cam_examples/full_cam.json
@@ -1,0 +1,54 @@
+{
+  "type": "cam",
+  "origin": "self",
+  "version": "0.1.0",
+  "source_uuid": "uuid14",
+  "timestamp": 1574778515424,
+  "message": {
+    "protocol_version": 42,
+    "station_id": 42,
+    "generation_delta": 42,
+    "basic_container": {
+      "station_type": 5,
+      "position": {
+        "latitude": 486263556,
+        "longitude": 22492123,
+        "altitude": 15000,
+        "accuracy": {
+          "semi_major_confidence": 1000,
+          "semi_minor_confidence": 100,
+          "semi_major_orientation": 800,
+          "altitude": 5
+        }
+      }
+    },
+    "high_freq_container": {
+      "heading": 1639,
+      "speed": 365,
+      "longitudinal_acceleration": 0,
+      "yaw_rate": -6,
+      "drive_direction": 0,
+      "vehicle_length": 45,
+      "vehicle_width": 17,
+      "curvature": 1,
+      "curvature_calculation_mode": 0,
+      "acceleration_control": "0011000",
+      "lane_position": 2,
+      "lateral_acceleration": 1,
+      "vertical_acceleration":-1,
+      "accuracy": {
+        "heading": 15,
+        "speed": 12,
+        "yaw_rate": 2,
+        "longitudinal_acceleration": 16,
+        "vehicle_length": 3,
+        "curvature": 0,
+        "vertical_acceleration": 5,
+        "lateral_acceleration": 0
+      }
+    },
+    "low_freq_container": {
+      "vehicle_role": 2
+    }
+  }
+}

--- a/cam_schema.js
+++ b/cam_schema.js
@@ -1,145 +1,287 @@
-camSchema = 
-{
-  "type": "object",
-  "$id": "#cam",
-  "required": [
-    "type",
-    "origin",
-    "version",
-    "source_uuid",
-    "timestamp",
-    "message"
-  ],
-  "properties": {
-    "type": {
-      "enum": ["cam"]
-    },
-    "origin": {
-      "type": "string",
-      "enum": [
-        "self",
-        "mec_app"
-      ],
-      "description": "the entity responsible for this message"
-    },
-    "version": {
-    	"type": "string",
-    	"examples": ["0.0.1", "1.0.0"],
-    	"description": "json message format version"
-    },
-    "source_uuid": {
-    	"type": "string",
-    	"examples": ["UNKNOWN"]
-    },
-    "timestamp": {
-    	"type": "integer",
-    	"description": "the timestamp when the message was generated in milliseconds",
-    	"examples": [1574778515424],
-    	"minimum": 1514764800000,
-    	"maximum": 1830297600000
-    },
-    "message": {
-    	"type": "object",
-      "required": [
-        "protocol_version",
-        "station_id",
-        "generation_delta",
-        "basic_container",
-        "high_freq_container",
-        "low_freq_container"
-      ],
-      "properties": {
-        "protocol_version": {
-          "type": "integer", 
-          "minimum": 0,
-          "maximum": 255,
-          "examples": [1]
-        },
-        "station_id": {
-          "type": "integer", 
-          "minimum": 0,
-          "maximum": 4294967295,
-          "examples": [1]
-        },
-        "generation_delta": {
-          "type": "integer", 
-          "description": "in milliseconds",
-          "minimum": 0,
-          "maximum": 65535,
-          "examples": [1]
-        },
-        "basic_container": {
-          "type": "object",
-          "required": ["station_type", "position"],
-          "properties": {
-            "station_type": {
-              "description": "unknown(0), pedestrian(1), cyclist(2), moped(3), motorcycle(4), passengerCar(5), bus(6), lightTruck(7), heavyTruck(8), trailer(9), specialVehicles(10), tram(11), roadSideUnit(15)",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
+camSchema =
+    {
+        "type": "object",
+        "$id": "#cam",
+        "required": [
+            "type",
+            "origin",
+            "version",
+            "source_uuid",
+            "timestamp",
+            "message"
+        ],
+        "properties": {
+            "type": {
+                "enum": ["cam"]
             },
-            "position": {
-              "type": "object",
-              "required": ["latitude", "longitude"],
-              "properties": {
-                "latitude": {
-                  "type": "integer",
-                  "description": "latitude in microdegrees",
-                  "minimum": -900000000,
-                  "maximum": 900000001
-                },
-                "longitude": {
-                  "type": "integer",
-                  "description": "longitude in microdegrees",
-                  "minimum": -1800000000,
-                  "maximum": 1800000001
+            "origin": {
+                "type": "string",
+                "enum": [
+                    "self",
+                    "mec_app"
+                ],
+                "description": "the entity responsible for this message"
+            },
+            "version": {
+                "type": "string",
+                "examples": ["0.0.1", "1.0.0"],
+                "description": "json message format version"
+            },
+            "source_uuid": {
+                "type": "string",
+                "examples": ["UNKNOWN"]
+            },
+            "timestamp": {
+                "type": "integer",
+                "description": "Unit: millisecond. The timestamp when the message was generated since Unix Epoch (1970/01/01)",
+                "examples": [1574778515424],
+                "minimum": 1514764800000,
+                "maximum": 1830297600000
+            },
+            "message": {
+                "type": "object",
+                "required": [
+                    "protocol_version",
+                    "station_id",
+                    "generation_delta",
+                    "basic_container",
+                    "high_freq_container",
+                    "low_freq_container"
+                ],
+                "properties": {
+                    "protocol_version": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "examples": [1]
+                    },
+                    "station_id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 4294967295,
+                        "examples": [1]
+                    },
+                    "generation_delta": {
+                        "type": "integer",
+                        "description": "in milliseconds",
+                        "minimum": 0,
+                        "maximum": 65535,
+                        "examples": [1]
+                    },
+                    "basic_container": {
+                        "type": "object",
+                        "required": ["station_type", "position"],
+                        "properties": {
+                            "station_type": {
+                                "description": "unknown(0), pedestrian(1), cyclist(2), moped(3), motorcycle(4), passengerCar(5), bus(6), lightTruck(7), heavyTruck(8), trailer(9), specialVehicles(10), tram(11), roadSideUnit(15)",
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 255
+                            },
+                            "position": {
+                                "type": "object",
+                                "required": ["latitude", "longitude"],
+                                "properties": {
+                                    "latitude": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 microdegree. oneMicrodegreeNorth (10), oneMicrodegreeSouth (-10), unavailable(900000001)",
+                                        "minimum": -900000000,
+                                        "maximum": 900000001
+                                    },
+                                    "longitude": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 microdegree. oneMicrodegreeEast (10), oneMicrodegreeWest (-10), unavailable(1800000001)",
+                                        "minimum": -1800000000,
+                                        "maximum": 1800000001
+                                    },
+                                    "altitude": {
+                                        "type": "integer",
+                                        "description": "Unit: 0.01 meter. referenceEllipsoidSurface(0), oneCentimeter(1), unavailable(800001)} (-100000..800001)",
+                                        "minimum": -100000,
+                                        "maximum": 800001
+                                    },
+                                    "accuracy": {
+                                        "type": "object",
+                                        "properties": {
+                                            "semi_major_confidence": {
+                                                "type": "integer",
+                                                "description": "Unit: cm. oneCentimeter(1), outOfRange(4094), unavailable(4095)",
+                                                "minimum": 0,
+                                                "maximum": 4095
+                                            },
+                                            "semi_minor_confidence": {
+                                                "type": "integer",
+                                                "description": "Unit: cm. oneCentimeter(1), outOfRange(4094), unavailable(4095)",
+                                                "minimum": 0,
+                                                "maximum": 4095
+                                            },
+                                            "semi_major_orientation": {
+                                                "type": "integer",
+                                                "description": "Unit 0.1 degree. wgs84North(0), wgs84East(900), wgs84South(1800), wgs84West(2700), unavailable(3601)",
+                                                "minimum": 0,
+                                                "maximum": 3601
+                                            },
+                                            "altitude": {
+                                                "type": "integer",
+                                                "description": "alt-000-01 (0), alt-000-02 (1), alt-000-05 (2), alt-000-10 (3), alt-000-20 (4), alt-000-50 (5), alt-001-00 (6), alt-002-00 (7), alt-005-00 (8), alt-010-00 (9), alt-020-00 (10), alt-050-00 (11), alt-100-00 (12), alt-200-00 (13), outOfRange (14), unavailable (15)",
+                                                "minimum": 0,
+                                                "maximum": 15
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "high_freq_container": {
+                        "type": "object",
+                        "required": ["heading", "speed", "longitudinal_acceleration", "yaw_rate"],
+                        "properties": {
+                            "heading": {
+                                "type": "integer",
+                                "description": "Unit: 0,1 degree. wgs84North(0), wgs84East(900), wgs84South(1800), wgs84West(2700), unavailable(3601)",
+                                "minimum": 0,
+                                "maximum": 3601
+                            },
+                            "speed": {
+                                "type": "integer",
+                                "description": "Unit 0,01 m/s. standstill(0), oneCentimeterPerSec(1), unavailable(16383)",
+                                "minimum": 0,
+                                "maximum": 16383
+                            },
+                            "longitudinal_acceleration": {
+                                "description": "unit: 0,1 m/s2. pointOneMeterPerSecSquaredForward(1), pointOneMeterPerSecSquaredBackward(-1), unavailable(161)",
+                                "type": "integer",
+                                "minimum": -160,
+                                "maximum": 161
+                            },
+                            "yaw_rate": {
+                                "type": "integer",
+                                "description": "Unit: 0,01 degree/s. straight(0), degSec-000-01ToRight(-1), degSec-000-01ToLeft(1), unavailable(32767)",
+                                "minimum": -32766,
+                                "maximum": 32767
+                            },
+                            "drive_direction": {
+                                "type": "integer",
+                                "description": "forward (0), backward (1), unavailable (2)",
+                                "minimum": 0,
+                                "maximum": 2
+                            },
+                            "vehicle_length": {
+                                "type": "integer",
+                                "description": "Unit: 0.1 meter. tenCentimeters(1), outOfRange(1022), unavailable(1023)",
+                                "minimum": 1,
+                                "maximum": 1023
+                            },
+                            "vehicle_width": {
+                                "type": "integer",
+                                "description": "Unit: 0.1 meter. tenCentimeters(1), outOfRange(61), unavailable(62)",
+                                "minimum": 1,
+                                "maximum": 62
+                            },
+                            "curvature": {
+                                "type": "integer",
+                                "description": "Unit: 1 over 10 000 metres. straight(0), unavailable(1023)",
+                                "minimum": -1023,
+                                "maximum": 1023
+                            },
+                            "curvature_calculation_mode": {
+                                "type": "integer",
+                                "description": "It describes whether the yaw rate is used to calculate the curvature. yawRateUsed(0), yawRateNotUsed(1), unavailable(2)",
+                                "minimum": 0,
+                                "maximum": 2
+                            },
+                            "acceleration_control": {
+                                "type": "string",
+                                "description": "Current controlling mechanism for longitudinal movement of the vehicle. Represented as a bit string",
+                                "example": ["00000000", "1000000", "0000011"]
+                            },
+                            "lane_position": {
+                                "type": "integer",
+                                "description": "offTheRoad(-1), innerHardShoulder(0), innermostDrivingLane(1), secondLaneFromInside(2), outterHardShoulder(14)",
+                                "minimum": -1,
+                                "maximum": 14
+                            },
+                            "lateral_acceleration": {
+                                "type": "integer",
+                                "description": "Unit: 0.1 m/s2. pointOneMeterPerSecSquaredToRight(-1), pointOneMeterPerSecSquaredToLeft(1), unavailable(161)",
+                                "minimum": -160,
+                                "maximum": 161
+                            },
+                            "vertical_acceleration": {
+                                "type": "integer",
+                                "description": "Unit: 0.1 m/s2. pointOneMeterPerSecSquaredUp(1), pointOneMeterPerSecSquaredDown(-1), unavailable(161)",
+                                "minimum": -160,
+                                "maximum": 161
+                            },
+                            "accuracy": {
+                                "type": "object",
+                                "properties": {
+                                    "heading": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 degree. equalOrWithinZeroPointOneDegree (1), equalOrWithinOneDegree (10), outOfRange(126), unavailable(127)",
+                                        "minimum": 1,
+                                        "maximum": 127
+                                    },
+                                    "speed": {
+                                        "type": "integer",
+                                        "description": "Unit: 0.01 m/s. equalOrWithinOneCentimeterPerSec(1), equalOrWithinOneMeterPerSec(100), outOfRange(126), unavailable(127)",
+                                        "minimum": 1,
+                                        "maximum": 127
+                                    },
+                                    "yaw_rate": {
+                                        "type": "integer",
+                                        "description": "degSec-000-01 (0), degSec-000-05 (1), degSec-000-10 (2), degSec-001-00 (3), degSec-005-00 (4), degSec-010-00 (5), degSec-100-00 (6), outOfRange (7), unavailable (8)",
+                                        "minimum": 0,
+                                        "maximum": 8
+                                    },
+                                    "longitudinal_acceleration": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 m/s2. pointOneMeterPerSecSquared(1), outOfRange(101), unavailable(102)",
+                                        "minimum": 0,
+                                        "maximum": 102
+                                    },
+                                    "vehicle_length": {
+                                        "type": "integer",
+                                        "description": "noTrailerPresent(0), trailerPresentWithKnownLength(1), trailerPresentWithUnknownLength(2), trailerPresenceIsUnknown(3), unavailable(4)",
+                                        "minimum": 0,
+                                        "maximum": 4
+                                    },
+                                    "curvature": {
+                                        "type": "integer",
+                                        "description": "onePerMeter-0-00002 (0), onePerMeter-0-0001 (1), onePerMeter-0-0005 (2), onePerMeter-0-002 (3), onePerMeter-0-01 (4), onePerMeter-0-1 (5), outOfRange (6), unavailable (7)",
+                                        "minimum": 0,
+                                        "maximum": 7
+                                    },
+                                    "vertical_acceleration": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 m/s2. pointOneMeterPerSecSquared(1), outOfRange(101), unavailable(102)",
+                                        "minimum": 0,
+                                        "maximum": 102
+                                    },
+                                    "lateral_acceleration": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 m/s2. pointOneMeterPerSecSquared(1), outOfRange(101), unavailable(102)",
+                                        "minimum": 0,
+                                        "maximum": 102
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    "low_freq_container": {
+                        "type": "object",
+                        "required": ["vehicle_role"],
+                        "properties": {
+                            "vehicle_role": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 15,
+                                "description": "default(0), publicTransport(1), specialTransport(2), dangerousGoods(3), roadWork(4), rescue(5), emergency(6), safetyCar(7), agriculture(8),commercial(9),military(10),roadOperator(11),taxi(12), reserved1(13), reserved2(14), reserved3(15)"
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
-        },
-        "high_freq_container": {
-          "type": "object",
-          "required": ["heading", "speed", "longitudinal_acceleration", "yaw_rate"],
-          "properties": {
-            "heading": {
-              "type": "integer",
-              "description": "heading clockwise in 1/100 of degrees",
-              "minimum": 0,
-              "maximum": 3601
-            },
-            "speed": {
-              "type": "integer",
-              "description": "in centimeter per second",
-              "minimum": 0,
-              "maximum": 16383
-            },
-            "longitudinal_acceleration": {
-              "description": "in 0.1 meter per second squared",
-              "type": "integer",
-              "minimum": -160,
-              "maximum": 161
-            },
-            "yaw_rate": {
-              "type": "integer",
-              "minimum": -32766,
-              "maximum": 32767
-            }
-          }
-        },
-        "low_freq_container": {
-          "type": "object",
-          "required": ["vehicle_role"],
-          "properties": {
-            "vehicle_role": {
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 15,
-              "description": "default(0), publicTransport(1), specialTransport(2), dangerousGoods(3), roadWork(4), rescue(5), emergency(6), safetyCar(7), agriculture(8),commercial(9),military(10),roadOperator(11),taxi(12), reserved1(13), reserved2(14), reserved3(15)"
-            }
-          }
         }
-      }
-    }
-  }
-};
+    };

--- a/changelog.html
+++ b/changelog.html
@@ -1,0 +1,23 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+    <link href="./style.css" rel="stylesheet" type="text/css">
+</head>
+<body>
+<h1>V2X messages JSON validator</h1>
+<h2>Changelog</h2>
+<h3>2019/12/09</h3>
+<ul>
+    <li>FIX: detection_time and reference_time for DENM are now in ETSI-ITS timestamp</li>
+    <li>FEAT: unit in the description of every field for CAM and DENM</li>
+    <li>FEAT: add many optional fields including accuracy for CAM and DENM</li>
+    <li>FEAT: DENM and CAM examples with all optional fields</li>
+    <li>FEAT: changelog page</li>
+</ul>
+<h3>2019/12/02</h3>
+<ul>
+    <li>First version of CAM and DENM json schema</li>
+</ul>
+</body>
+</html>

--- a/denm_examples/basic_denm.json
+++ b/denm_examples/basic_denm.json
@@ -1,7 +1,7 @@
 {
   "type": "denm",
   "origin": "self",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "source_uuid": "uuid14",
   "timestamp": 1574778515425,
   "message": {
@@ -12,8 +12,8 @@
         "origin_station_id": 42,
         "sequence_number": 1
       },
-      "detection_time": 1574778515423,
-      "reference_time": 1574778515424,
+      "detection_time": 186244115423,
+      "reference_time": 186244115424,
       "event_position": {
         "latitude": 486263556,
         "longitude": 22492123

--- a/denm_examples/full_denm.json
+++ b/denm_examples/full_denm.json
@@ -1,0 +1,60 @@
+{
+  "type": "denm",
+  "origin": "self",
+  "version": "0.0.1",
+  "source_uuid": "uuid14",
+  "timestamp": 1574778515425,
+  "message": {
+    "protocol_version": 1,
+    "station_id": 42,
+    "management_container": {
+      "action_id": {
+        "origin_station_id": 42,
+        "sequence_number": 1
+      },
+      "detection_time": 186244115423,
+      "reference_time": 186244115424,
+      "termination": 0,
+      "event_position": {
+        "latitude": 486263556,
+        "longitude": 22492123,
+        "altitude": 1340,
+        "accuracy": {
+          "semi_major_confidence": 1000,
+          "semi_minor_confidence": 100,
+          "semi_major_orientation": 800,
+          "altitude": 5
+        }
+      },
+      "relevant_distance": 2,
+      "relevance_traffic_direction": 1,
+      "validity_duration": 180,
+      "transmission_interval": 1000,
+      "station_type": 5
+    },
+    "situation_container": {
+      "information_quality": 4,
+      "event_type": {
+        "cause": 1,
+        "subcause": 6
+      },
+      "linked_cause": {
+        "cause": 94,
+        "subcause": 2
+      }
+    },
+    "location_container": {
+      "event_speed": 1000,
+      "event_position_heading": 3500,
+      "road_type": 0,
+      "accuracy": {
+        "event_speed": 10,
+        "event_position_heading": 10
+      }
+    },
+    "alacarte_container": {
+      "lane_position": 2,
+      "position_solution_type": 3
+    }
+  }
+}

--- a/denm_schema.js
+++ b/denm_schema.js
@@ -1,177 +1,309 @@
-const denmSchema = 
-{
-  "type": "object",
-  "$id": "#denm",
-  "required": [
-    "type",
-    "origin",
-    "version",
-    "source_uuid",
-    "timestamp",
-    "message"
-  ],
-  "properties": {
-    "type": {
-      "enum": ["denm"]
-    },
-    "origin": {
-      "type": "string",
-      "enum": [
-        "self",
-        "mec_app"
-      ],
-      "description": "the entity responsible for this message"
-    },
-    "version": {
-    	"type": "string",
-    	"examples": ["0.0.1", "1.0.0"],
-    	"description": "json message format version"
-    },
-    "source_uuid": {
-    	"type": "string",
-    	"examples": ["UNKNOWN"]
-    },
-    "timestamp": {
-    	"type": "integer",
-    	"description": "the timestamp when the message was generated in milliseconds",
-    	"examples": [1574778515424],
-    	"minimum": 1514764800000,
-    	"maximum": 1830297600000
-    },
-    "message": {
-    	"type": "object",
-      "required": [
-        "protocol_version",
-        "station_id",
-        "management_container",
-        "situation_container"
-      ],
-      "properties": {
-        "protocol_version": {
-          "type": "integer", 
-          "minimum": 0,
-          "maximum": 255,
-          "examples": [1]
-        },
-        "station_id": {
-          "type": "integer", 
-          "minimum": 0,
-          "maximum": 4294967295,
-          "examples": [1]
-        },
-        "management_container": {
-          "type": "object",
-          "required": [
-            "action_id", 
-            "detection_time",
-            "reference_time",
-            "event_position",
-            "station_type"
-          ],
-          "properties": {
-            "action_id": {
-              "type": "object",
-              "required": ["origin_station_id", "sequence_number"],
-              "properties": {
-                "origin_station_id": {
-                  "type": "integer",
-                  "description": "identifier of an its station",
-                  "minimum": 0,
-                  "maximum": 4294967295
-                },
-                "sequence_number": {
-                  "type": "integer",
-                  "description": "The sequence number is set each time a new DENM is created. It is used to differentiate from events detected by the same ITS-S.",
-                  "minimum": 0,
-                  "maximum": 65535
+const denmSchema =
+    {
+        "type": "object",
+        "$id": "#denm",
+        "required": [
+            "type",
+            "origin",
+            "version",
+            "source_uuid",
+            "timestamp",
+            "message"
+        ],
+        "properties": {
+            "type": {
+                "enum": ["denm"]
+            },
+            "origin": {
+                "type": "string",
+                "enum": [
+                    "self",
+                    "mec_app",
+                    "onbaord-sensor",
+                    "backend"
+                ],
+                "description": "the entity responsible for this message"
+            },
+            "version": {
+                "type": "string",
+                "examples": ["0.1.0", "1.0.0"],
+                "description": "json message format version"
+            },
+            "source_uuid": {
+                "type": "string",
+                "examples": [
+                    "UNKNOWN",
+                    "CCU6",
+                    "MEC2"
+                ]
+            },
+            "timestamp": {
+                "type": "integer",
+                "description": "Unit: millisecond. The timestamp when the message was generated since Unix Epoch (1970/01/01)",
+                "examples": [1574778515424],
+                "minimum": 1514764800000,
+                "maximum": 1830297600000
+            },
+            "message": {
+                "type": "object",
+                "required": [
+                    "protocol_version",
+                    "station_id",
+                    "management_container",
+                    "situation_container"
+                ],
+                "properties": {
+                    "protocol_version": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 255,
+                        "examples": [1]
+                    },
+                    "station_id": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 4294967295,
+                        "examples": [1]
+                    },
+                    "management_container": {
+                        "type": "object",
+                        "required": [
+                            "action_id",
+                            "detection_time",
+                            "reference_time",
+                            "event_position",
+                            "station_type"
+                        ],
+                        "properties": {
+                            "action_id": {
+                                "type": "object",
+                                "required": [
+                                    "origin_station_id", 
+                                    "sequence_number"
+                                ],
+                                "properties": {
+                                    "origin_station_id": {
+                                        "type": "integer",
+                                        "description": "identifier of an its station",
+                                        "minimum": 0,
+                                        "maximum": 4294967295
+                                    },
+                                    "sequence_number": {
+                                        "type": "integer",
+                                        "description": "The sequence number is set each time a new DENM is created. It is used to differentiate from events detected by the same ITS-S.",
+                                        "minimum": 0,
+                                        "maximum": 65535
+                                    }
+                                }
+                            },
+                            "detection_time": {
+                                "type": "integer",
+                                "description": "Unit: millisecond since ETSI epoch (2004/01/01). Time at which the event is detected by the originating ITS-S. For the DENM repetition, this DE shall remain unchanged.",
+                                "minimum": 126230400000,
+                                "maximum": 441763200000
+                            },
+                            "reference_time": {
+                                "type": "integer",
+                                "description": "Unit: millisecond since ETSI epoch (2004/01/01). Time at which a new DENM, an update DENM or a cancellation DENM is generated.",
+                                "minimum": 126230400000,
+                                "maximum": 441763200000
+                            },
+                            "termination": {
+                                "type": "integer",
+                                "description": "isCancellation(0), isNegation (1)",
+                                "minimum": 0,
+                                "maximum": 1
+                            },
+                            "event_position": {
+                                "type": "object",
+                                "description": "Geographical position of the detected event.",
+                                "required": ["latitude", "longitude"],
+                                "properties": {
+                                    "latitude": {
+                                        "type": "integer",
+                                        "description": "latitude in microdegrees",
+                                        "minimum": -900000000,
+                                        "maximum": 900000001
+                                    },
+                                    "longitude": {
+                                        "type": "integer",
+                                        "description": "longitude in microdegrees",
+                                        "minimum": -1800000000,
+                                        "maximum": 1800000001
+                                    },
+                                    "altitude": {
+                                        "type": "integer",
+                                        "description": "Unit: 0.01 meter. referenceEllipsoidSurface(0), oneCentimeter(1), unavailable(800001)} (-100000..800001)",
+                                        "minimum": -100000,
+                                        "maximum": 800001
+                                    },
+                                    "accuracy": {
+                                        "type": "object",
+                                        "properties": {
+                                            "semi_major_confidence": {
+                                                "type": "integer",
+                                                "description": "Unit: cm. oneCentimeter(1), outOfRange(4094), unavailable(4095)",
+                                                "minimum": 0,
+                                                "maximum": 4095
+                                            },
+                                            "semi_minor_confidence": {
+                                                "type": "integer",
+                                                "description": "Unit: cm. oneCentimeter(1), outOfRange(4094), unavailable(4095)",
+                                                "minimum": 0,
+                                                "maximum": 4095
+                                            },
+                                            "semi_major_orientation": {
+                                                "type": "integer",
+                                                "description": "Unit 0.1 degree. wgs84North(0), wgs84East(900), wgs84South(1800), wgs84West(2700), unavailable(3601)",
+                                                "minimum": 0,
+                                                "maximum": 3601
+                                            },
+                                            "altitude": {
+                                                "type": "integer",
+                                                "description": "Absolute accuracy of a reported altitude value of a geographical point for a predefined confidence level (e.g. 95 %).",
+                                                "minimum": 0,
+                                                "maximum": 15
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "relevant_distance": {
+                                "type": "integer",
+                                "description": "lessThan50m(0), lessThan100m(1), lessThan200m(2), lessThan500m(3), lessThan1000m(4), lessThan5km(5), lessThan10km(6), over10km(7)",
+                                "minimum": 0,
+                                "maximum": 7
+                            },
+                            "relevance_traffic_direction": {
+                                "type": "integer",
+                                "description": "allTrafficDirections(0), upstreamTraffic(1), downstreamTraffic(2), oppositeTraffic(3)",
+                                "minimum": 0,
+                                "maximum": 3
+                            },
+                            "validity_duration": {
+                                "type": "integer",
+                                "description": "Unit: second. timeOfDetection(0), oneSecondAfterDetection(1)",
+                                "minimum": 0,
+                                "maximum": 86400
+                            },
+                            "transmission_interval": {
+                                "type": "integer",
+                                "description": "Unit: millisecond. oneMilliSecond(1), tenSeconds(10000)",
+                                "minimum": 1,
+                                "maximum": 10000
+                            },
+                            "station_type": {
+                                "description": "unknown(0), pedestrian(1), cyclist(2), moped(3), motorcycle(4), passengerCar(5), bus(6), lightTruck(7), heavyTruck(8), trailer(9), specialVehicles(10), tram(11), roadSideUnit(15)",
+                                "type": "integer",
+                                "minimum": 0,
+                                "maximum": 255
+                            }
+                        }
+                    },
+                    "situation_container": {
+                        "type": "object",
+                        "required": ["event_type"],
+                        "properties": {
+                            "information_quality": {
+                                "type": "integer",
+                                "description": "unavailable(0), lowest(1), highest(7)",
+                                "minimum": 0,
+                                "maximum": 7
+                            },
+                            "event_type": {
+                                "type": "object",
+                                "required": ["cause", "subcause"],
+                                "properties": {
+                                    "cause": {
+                                        "type": "integer",
+                                        "description": "reserved (0), trafficCondition (1), accident (2), roadworks (3), impassability (5), adverseWeatherCondition-Adhesion (6), aquaplannning (7), hazardousLocation-SurfaceCondition (9), hazardousLocation-ObstacleOnTheRoad (10), hazardousLocation-AnimalOnTheRoad (11), humanPresenceOnTheRoad (12), wrongWayDriving (14), rescueAndRecoveryWorkInProgress (15), adverseWeatherCondition-ExtremeWeatherCondition (17), adverseWeatherCondition-Visibility (18), adverseWeatherCondition-Precipitation (19), slowVehicle (26), dangerousEndOfQueue (27), vehicleBreakdown (91), postCrash (92), humanProblem (93), stationaryVehicle (94), emergencyVehicleApproaching (95), hazardousLocation-DangerousCurve (96), collisionRisk (97), signalViolation (98), dangerousSituation (99)",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    },
+                                    "subcause": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    }
+                                }
+                            },
+                            "linked_cause": {
+                                "type": "object",
+                                "required": ["cause", "subcause"],
+                                "properties": {
+                                    "cause": {
+                                        "type": "integer",
+                                        "description": "reserved (0), trafficCondition (1), accident (2), roadworks (3), impassability (5), adverseWeatherCondition-Adhesion (6), aquaplannning (7), hazardousLocation-SurfaceCondition (9), hazardousLocation-ObstacleOnTheRoad (10), hazardousLocation-AnimalOnTheRoad (11), humanPresenceOnTheRoad (12), wrongWayDriving (14), rescueAndRecoveryWorkInProgress (15), adverseWeatherCondition-ExtremeWeatherCondition (17), adverseWeatherCondition-Visibility (18), adverseWeatherCondition-Precipitation (19), slowVehicle (26), dangerousEndOfQueue (27), vehicleBreakdown (91), postCrash (92), humanProblem (93), stationaryVehicle (94), emergencyVehicleApproaching (95), hazardousLocation-DangerousCurve (96), collisionRisk (97), signalViolation (98), dangerousSituation (99)",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    },
+                                    "subcause": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 255
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "location_container": {
+                        "type": "object",
+                        "properties": {
+                            "event_speed": {
+                                "type": "integer",
+                                "description": "Unit 0,01 m/s. standstill(0), oneCentimeterPerSec(1), unavailable(16383)",
+                                "minimum": 0,
+                                "maximum": 16383
+                            },
+                            "event_position_heading": {
+                                "type": "integer",
+                                "description": "Unit: 0,1 degree. wgs84North(0), wgs84East(900), wgs84South(1800), wgs84West(2700), unavailable(3601)",
+                                "minimum": 0,
+                                "maximum": 3601
+                            },
+                            "road_type": {
+                                "type": "integer",
+                                "description": "Type of a road segment. urban-NoStructuralSeparationToOppositeLanes(0), urban-WithStructuralSeparationToOppositeLanes(1), nonUrban-NoStructuralSeparationToOppositeLanes(2), nonUrban-WithStructuralSeparationToOppositeLanes(3)",
+                                "minimum": 0,
+                                "maximum": 3
+                            },
+                            "accuracy": {
+                                "type": "object",
+                                "properties": {
+                                    "event_speed": {
+                                        "type": "integer",
+                                        "description": "Unit: 0.01 m/s. equalOrWithinOneCentimeterPerSec(1), equalOrWithinOneMeterPerSec(100), outOfRange(126), unavailable(127)",
+                                        "minimum": 1,
+                                        "maximum": 127
+                                    },
+                                    "event_position_heading": {
+                                        "type": "integer",
+                                        "description": "Unit: 0,1 degree. equalOrWithinZeroPointOneDegree (1), equalOrWithinOneDegree (10), outOfRange(126), unavailable(127)",
+                                        "minimum": 1,
+                                        "maximum": 127
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "alacarte_container": {
+                        "type": "object",
+                        "properties": {
+                            "lane_position": {
+                                "type": "integer",
+                                "description": "offTheRoad(-1), innerHardShoulder(0), innermostDrivingLane(1), secondLaneFromInside(2), outterHardShoulder(14)",
+                                "minimum": -1,
+                                "maximum": 14
+                            },
+                            "position_solution_type": {
+                                "type": "integer",
+                                "description": "noPositioningSolution(0), sGNSS(1), dGNSS(2), sGNSSplusDR(3), dGNSSplusDR(4), dR(5), ...",
+                                "minimum": 0,
+                                "maximum": 5
+                            }
+                        }
+                    }
                 }
-              }
-            },
-            "detection_time": {
-              "type":"integer",
-              "description": "Time at which the event is detected by the originating ITS-S. For the DENM repetition, this DE shall remain unchanged.",
-              "minimum": 1514764800000,
-              "maximum": 1830297600000
-            },
-            "reference_time": {
-              "type": "integer",
-              "description": "This DE refers to the time at which a new DENM, an update DENM or a cancellation DENM is generated.",
-              "minimum": 1514764800000,
-              "maximum": 1830297600000
-            },
-            "event_position": {
-              "type": "object",
-              "description": "Geographical position of the detected event.",
-              "required": ["latitude", "longitude"],
-              "properties": {
-                "latitude": {
-                  "type": "integer",
-                  "description": "latitude in microdegrees",
-                  "minimum": -900000000,
-                  "maximum": 900000001
-                },
-                "longitude": {
-                  "type": "integer",
-                  "description": "longitude in microdegrees",
-                  "minimum": -1800000000,
-                  "maximum": 1800000001
-                }
-              }
-            },
-            "station_type": {
-              "description": "unknown(0), pedestrian(1), cyclist(2), moped(3), motorcycle(4), passengerCar(5), bus(6), lightTruck(7), heavyTruck(8), trailer(9), specialVehicles(10), tram(11), roadSideUnit(15)",
-              "type": "integer",
-              "minimum": 0,
-              "maximum": 255
             }
-          }
-        },
-        "situation_container": {
-          "type": "object",
-          "required": ["event_type"],
-          "properties": {
-            "event_type": {
-              "type": "object",
-              "required": ["cause", "subcause"],
-              "properties": {
-                "cause": {
-                  "type": "integer",
-                  "description": "reserved (0), trafficCondition (1), accident (2), roadworks (3), impassability (5), adverseWeatherCondition-Adhesion (6), aquaplannning (7), hazardousLocation-SurfaceCondition (9), hazardousLocation-ObstacleOnTheRoad (10), hazardousLocation-AnimalOnTheRoad (11), humanPresenceOnTheRoad (12), wrongWayDriving (14), rescueAndRecoveryWorkInProgress (15), adverseWeatherCondition-ExtremeWeatherCondition (17), adverseWeatherCondition-Visibility (18), adverseWeatherCondition-Precipitation (19), slowVehicle (26), dangerousEndOfQueue (27), vehicleBreakdown (91), postCrash (92), humanProblem (93), stationaryVehicle (94), emergencyVehicleApproaching (95), hazardousLocation-DangerousCurve (96), collisionRisk (97), signalViolation (98), dangerousSituation (99)",
-                  "minimum": 0,
-                  "maximum": 255
-                },
-                "subcause": {
-                  "type": "integer",
-                  "minimum": 0,
-                  "maximum": 255
-                }
-              }
-            }
-          }
         }
-      }
-    }
-  }
-}
-
-/*
-    "management_container": {
-      "action_id": {
-        "origin_station_id": 42,
-        "sequence_number": 1
-      },
-      "detection_time": 1574778515424,
-      "reference_time": 1574778515424,
-      "event_position": {
-        "latitude": 486263556,
-        "longitude": 22492123
-      },
-      "station_type": 5
-    },
-    "situation_container": {
-      "event_type": {
-        "cause": 94,
-        "subcause": 2
-      }
-    }
-*/
+    };

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <option>full_denm.json</option>
         </select>
         <button type="submit" onclick="loadSample('DENM')">Ok</button>
-        <a href="cam_schema.js" target="_blank">
+        <a href="denm_schema.js" target="_blank">
             <button type="button" class="schema-button"> show schema</button>
         </a>
         <div id="denm-error" class="error-message"></div>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,13 @@
 </head>
 <body>
 <h1>V2X messages JSON validator</h1>
+<a href="changelog.html" id="changelog">changelog</a>
 <div class="wrapper">
     <div class="left-editor-header">
         <H2>CAM</H2>
         <select id="select-cam">
             <option>basic_cam.json</option>
+            <option>full_cam.json</option>
         </select>
         <button type="submit" onclick="loadSample('CAM')">Ok</button>
         <a href="cam_schema.js" target="_blank">
@@ -29,6 +31,7 @@
         <H2>DENM</H2>
         <select id="select-denm">
             <option>basic_denm.json</option>
+            <option>full_denm.json</option>
         </select>
         <button type="submit" onclick="loadSample('DENM')">Ok</button>
         <a href="cam_schema.js" target="_blank">

--- a/style.css
+++ b/style.css
@@ -38,6 +38,12 @@
     color: red;
 }
 
+#changelog {
+    position: absolute;
+    color: steelblue;
+    right: 0;
+}
+
 @media (max-width: 768px) {
     /* For mobile phones: */
     .wrapper {


### PR DESCRIPTION
# What's new
* FIX: detection_time and reference_time for DENM are now in ETSI-ITS timestamp
* FEAT: unit in the description of every field for CAM and DENM
* FEAT: add many optional fields including accuracy for CAM and DENM
* FEAT: DENM and CAM examples with all optional fields
* FEAT: changelog page

# test
test using `python -m SimpleHTTPServer`